### PR TITLE
Fix `Result.from` to include `gc_stats`

### DIFF
--- a/lib/minitest/gcstats.rb
+++ b/lib/minitest/gcstats.rb
@@ -41,11 +41,24 @@ module Minitest::GCStats
   end
 end
 
-class Minitest::Result
+module Minitest::GCStats::Result
   attr_accessor :gc_stats
+
+  def self.prepended klass
+    klass.singleton_class.prepend ClassMethods
+  end
+
+  module ClassMethods
+    def from runnable
+      r = super
+      r.gc_stats = runnable.gc_stats
+      r
+    end
+  end
 end
 
 Minitest::Test.prepend Minitest::GCStats
+Minitest::Result.prepend Minitest::GCStats::Result
 
 module Minitest::Assertions
   ##


### PR DESCRIPTION
I tested this gem on the `rails/rails` codebase and got an error:
```
./Users/fatkodima/.asdf/installs/ruby/3.2.1/lib/ruby/gems/3.2.0/gems/minitest-gcstats-1.3.0/lib/minitest/gcstats.rb:93:in `report': undefined method `/' for nil:NilClass (NoMethodError)

    pct = total / 100.0
                ^
	from /Users/fatkodima/.asdf/installs/ruby/3.2.1/lib/ruby/gems/3.2.0/gems/minitest-5.19.0/lib/minitest.rb:928:in `each'
```

To reproduce:
```bash
$ cd activerecord
$ TESTOPTS="-g" TEST=test/cases/reload_models_test.rb rake test:postgresql
```

This is because rails uses `Minitest::Result.from` (https://github.com/rails/rails/blob/ed0c34d1e08497a9b2251e91089328452df4c696/activesupport/lib/active_support/testing/isolation.rb#L48) which does not set `gc_stats`. 

With this fix, everything works as expected.